### PR TITLE
feat: logic of modifying default tooltip

### DIFF
--- a/src/main/java/com/castlelecs/missedbundle/MissedBundle.java
+++ b/src/main/java/com/castlelecs/missedbundle/MissedBundle.java
@@ -1,19 +1,21 @@
 package com.castlelecs.missedbundle;
 
 import com.castlelecs.missedbundle.factories.ItemsFactory;
-import com.castlelecs.missedbundle.factories.ItemsType;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
+
 @Mod(MissedBundle.MODID)
 public class MissedBundle {
+
     public static final String MODID = "missedbundle";
+
+    // MARK: - Init
 
     public MissedBundle() {
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        ItemsFactory itemsFactory = new ItemsFactory();
 
-        itemsFactory.registerItems(bus, ItemsType.values());
+        ItemsFactory.shared.registerItems(bus);;
     }
 }

--- a/src/main/java/com/castlelecs/missedbundle/factories/ItemsFactory.java
+++ b/src/main/java/com/castlelecs/missedbundle/factories/ItemsFactory.java
@@ -1,35 +1,26 @@
 package com.castlelecs.missedbundle.factories;
 
 import com.castlelecs.missedbundle.MissedBundle;
-import com.castlelecs.missedbundle.items.BundleItem;
+import com.castlelecs.missedbundle.utilities.RegistrationFactory;
+import com.castlelecs.missedbundle.utilities.Singleton;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
-public class ItemsFactory {
+public class ItemsFactory extends RegistrationFactory<Item> implements Singleton {
 
     private final DeferredRegister<Item> items = DeferredRegister.create(ForgeRegistries.ITEMS, MissedBundle.MODID);
 
-    public final void registerItems(IEventBus bus, ItemsType[] itemsTypes) {
-        for (ItemsType itemType : itemsTypes) {
+    public final static ItemsFactory shared = new ItemsFactory();
 
-            switch (itemType) {
-                case BUNDLE:
-                    items.register(itemType.rawValue, this::createBundleItem);
-                default:
-                    break;
-            }
-        }
+    // MARK: - Init
 
-        items.register(bus);
+    private ItemsFactory() { }
 
-        return;
-    }
+    // MARK: - Public methods
 
-    private final Item createBundleItem() {
-        return new BundleItem();
+    public void registerItems(IEventBus bus) {
+        super.register(bus, items, ItemsType.values());
     }
 }

--- a/src/main/java/com/castlelecs/missedbundle/factories/ItemsType.java
+++ b/src/main/java/com/castlelecs/missedbundle/factories/ItemsType.java
@@ -1,11 +1,32 @@
 package com.castlelecs.missedbundle.factories;
 
-public enum ItemsType {
+import com.castlelecs.missedbundle.items.bundle.BundleItem;
+import com.castlelecs.missedbundle.utilities.RegistryType;
+import net.minecraft.world.item.Item;
+
+public enum ItemsType implements RegistryType<Item> {
     BUNDLE("bundle");
 
     public final String rawValue;
 
     ItemsType(String rawValue) {
         this.rawValue = rawValue;
+    }
+
+    // MARK: - Overrided methods
+
+    @Override
+    public String getRawValue() {
+        return this.rawValue;
+    }
+
+    @Override
+    public Item getItem() {
+        switch (this) {
+            case BUNDLE:
+                return BundleItem.shared;
+            default:
+                return null;
+        }
     }
 }

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/BundleItem.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/BundleItem.java
@@ -1,5 +1,6 @@
-package com.castlelecs.missedbundle.items;
+package com.castlelecs.missedbundle.items.bundle;
 
+import com.castlelecs.missedbundle.utilities.Singleton;
 import net.minecraft.world.entity.SlotAccess;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
@@ -8,11 +9,13 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
-public final class BundleItem extends Item {
+public final class BundleItem extends Item implements Singleton {
+
+    public static final BundleItem shared = new BundleItem();
 
     // MARK: - Init
 
-    public BundleItem() {
+    private BundleItem() {
         super(new BundleProperties());
     }
 

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/BundleProperties.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/BundleProperties.java
@@ -1,4 +1,4 @@
-package com.castlelecs.missedbundle.items;
+package com.castlelecs.missedbundle.items.bundle;
 
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
@@ -10,7 +10,7 @@ public final class BundleProperties extends Item.Properties {
         setup();
     }
 
-    private final void setup() {
+    private void setup() {
         tab(CreativeModeTab.TAB_TOOLS);
         stacksTo(1);
     }

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/tooltip/BundleTooltipComponent.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/tooltip/BundleTooltipComponent.java
@@ -1,0 +1,8 @@
+package com.castlelecs.missedbundle.items.bundle.tooltip;
+
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+
+/**
+ * A component which will be used to draw bundle's tooltip
+ */
+public record BundleTooltipComponent(String currentAmount, String maxAmount) implements TooltipComponent { }

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/tooltip/ClientBundleTooltipComponent.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/tooltip/ClientBundleTooltipComponent.java
@@ -1,0 +1,50 @@
+package com.castlelecs.missedbundle.items.bundle.tooltip;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Matrix4f;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.network.chat.Style;
+import net.minecraft.util.FormattedCharSequence;
+
+
+/**
+ * A client component which draws components in the tooltip
+ */
+public class ClientBundleTooltipComponent implements ClientTooltipComponent {
+
+    private final BundleTooltipComponent component;
+
+    public ClientBundleTooltipComponent(BundleTooltipComponent component) {
+        this.component = component;
+    }
+
+    @Override
+    public int getHeight() {
+        // TODO: if will be used in the future move to constants
+        // 9 - default font size
+        return 9;
+    }
+
+    @Override
+    public int getWidth(Font font) {
+        return font.lineHeight;
+    }
+
+    @Override
+    public void renderText(Font font, int x, int y, Matrix4f matrixStack, MultiBufferSource.BufferSource bufferSource) {
+        String amountText = component.currentAmount() + " / " + component.maxAmount();
+
+        var textComponent = ClientTooltipComponent.create(FormattedCharSequence.forward(amountText, Style.EMPTY));
+
+        textComponent.renderText(font, x, y, matrixStack, bufferSource);
+    }
+
+    @Override
+    public void renderImage(Font font, int x, int y, PoseStack poseStack, ItemRenderer itemRenderer, int p_194053_) {
+        ClientTooltipComponent.super.renderImage(font, x, y, poseStack, itemRenderer, p_194053_);
+    }
+}
+

--- a/src/main/java/com/castlelecs/missedbundle/subscriptions/CommonSubscriber.java
+++ b/src/main/java/com/castlelecs/missedbundle/subscriptions/CommonSubscriber.java
@@ -1,0 +1,42 @@
+package com.castlelecs.missedbundle.subscriptions;
+
+import com.castlelecs.missedbundle.MissedBundle;
+import com.castlelecs.missedbundle.factories.ItemsFactory;
+import com.castlelecs.missedbundle.items.bundle.BundleItem;
+import com.castlelecs.missedbundle.items.bundle.tooltip.BundleTooltipComponent;
+import com.castlelecs.missedbundle.items.bundle.tooltip.ClientBundleTooltipComponent;
+import com.mojang.datafixers.util.Either;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterClientTooltipComponentFactoriesEvent;
+import net.minecraftforge.client.event.RenderTooltipEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+
+/**
+ * A subscriber for common events.
+ * <p>
+ * Every other more "specific" subscriber should be added as an inner class
+ * </p>
+ */
+@Mod.EventBusSubscriber(value = Dist.CLIENT, modid = MissedBundle.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class CommonSubscriber {
+    @SubscribeEvent
+    public static void registerTooltip(RegisterClientTooltipComponentFactoriesEvent event) {
+        event.register(BundleTooltipComponent.class, ClientBundleTooltipComponent::new);
+    }
+
+    // MARK: - TooltipSubscriber
+
+    /**
+     * A subscriber for rendering custom tooltips
+     */
+    @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = MissedBundle.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+    public static class TooltipSubscriber {
+        @SubscribeEvent
+        public static void showTooltip(RenderTooltipEvent.GatherComponents event) {
+            if (event.getItemStack().is(BundleItem.shared))
+                event.getTooltipElements().add(Either.right(new BundleTooltipComponent("1", "10")));
+        }
+    }
+}

--- a/src/main/java/com/castlelecs/missedbundle/utilities/RegistrationFactory.java
+++ b/src/main/java/com/castlelecs/missedbundle/utilities/RegistrationFactory.java
@@ -1,0 +1,16 @@
+package com.castlelecs.missedbundle.utilities;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+
+public abstract class RegistrationFactory<Type> {
+
+    public void register(IEventBus bus, DeferredRegister<Type> register, RegistryType<Type>[] types) {
+        for (var type : types)
+            register.register(type.getRawValue(), type::getItem);
+
+        register.register(bus);
+
+        return;
+    }
+}

--- a/src/main/java/com/castlelecs/missedbundle/utilities/RegistryType.java
+++ b/src/main/java/com/castlelecs/missedbundle/utilities/RegistryType.java
@@ -1,0 +1,6 @@
+package com.castlelecs.missedbundle.utilities;
+
+public interface RegistryType<Type> {
+    String getRawValue();
+    Type getItem();
+}

--- a/src/main/java/com/castlelecs/missedbundle/utilities/Singleton.java
+++ b/src/main/java/com/castlelecs/missedbundle/utilities/Singleton.java
@@ -1,0 +1,5 @@
+package com.castlelecs.missedbundle.utilities;
+
+public interface Singleton {
+     Singleton shared = null;
+}


### PR DESCRIPTION
# Tooltip

Тултип (tooltip) - это специальная область, которая появляется рядом с курсором в инвентаре при наведении на нее. Обычно в ней указывается Имя предмета и какая-либо побочная информация (прочность, register_name и тд).

### Пример работы тултипа

https://user-images.githubusercontent.com/69932531/185763130-e4915e7c-7cb5-4377-ad8a-41ca8f259744.mov

## Принцип работы

Для того, чтобы добавить свой компонент в тултип необходимо сделать две вещи:
1. Зарегистрировать сам компонент и объект который будет его отрисовывать;
2. Подписаться на появление тултипов и при необходимости добавлять наш компонент для отображения.

### Реализация

| Объект | Назначение |
| --- | --- |
| `BundleTooltipComponent` |  Компонент, который будет добавляться на тултип. Данный класс несет в себе необходимую для этого информацию. Пока что данные не существенны и захардкожены |
| `ClientBundleTooltipComponent` | Класс, который будет используя данные компонента рисовать его в тултипе. Временно потображает обычный текст типа "1 / 10" |
| `CommonSubscriber` | Класс, предназначенный для регистраций. В нашей реализации у него пока один статичный метод `void registerTooltip(event:)` регистрирующий компонент и класс его добавляющий |
| `TooltipSubscriber`| Подкласс класса `CommonSubscriber`. Предназначен для определения итема, которому будет в тултип добавляться наш кастомный компонент. Для этого у него есть метод `void showTooltip(event:)` |

# Минорные изменения

## Рефакторинг

- Изменилась иерархия папок в проекте;
- Были добавлены два новых интерфейса: `Singleton`, `RegistryType`. Первый обозначает синглтон классы и обязывает реализовать свойство `shared`. Второй предназначен для определения объектов, которые могут иметь `rawValue` и хранить в себе какой-либо внутренний объект. Обязывает реализовать два метода: `void getRawValue()`, `Type getItem()`;
- Был добавлен абстрактный класс `RegistrationFactory`. Помогающий проще реализовывать регистрацию объектов. Внутри данного класса реализован метод `void register(bus, register, types)`, который проходится по типам, регистрирует их с помощью `register`, а потом регистрирует сам `register` с помощью `bus`;
- `BundleItem` и `ItemsFactory` теперь соответствуют интерфесу `Singlton`;
- `ItemsFactory` теперь наследуется от `RegistrationFactory`.

