### PR TITLE
Fix/behaviour on appending items to bundle

### DIFF
--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/BundleItem.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/BundleItem.java
@@ -46,10 +46,7 @@ public final class BundleItem extends Item implements Singleton {
 
         // Put an item into the bundle
         if (actionType == ClickAction.SECONDARY && otherStack.getItem() != Items.AIR) {
-            InventoryHelper.saveItems(otherStack, bundleStack, () -> {
-                removeItemFromSlot(slot, otherStack);
-            });
-
+            InventoryHelper.saveItems(otherStack, bundleStack);
             updateFullnessIndicator(bundleStack);
 
             return true;
@@ -58,7 +55,6 @@ public final class BundleItem extends Item implements Singleton {
         // Put an item from the bundle to the slot
         if (actionType == ClickAction.SECONDARY && otherStack.getItem() == Items.AIR) {
             addItemToSlot(bundleStack, slot);
-
             updateFullnessIndicator(bundleStack);
 
             return true;
@@ -77,10 +73,7 @@ public final class BundleItem extends Item implements Singleton {
 
         // Put an item into the bundle
         if (actionType == ClickAction.SECONDARY && otherStack.getItem() != Items.AIR) {
-            InventoryHelper.saveItems(otherStack, bundleStack, () -> {
-                removeCarriedItem(player);
-            });
-
+            InventoryHelper.saveItems(otherStack, bundleStack);
             updateFullnessIndicator(bundleStack);
 
             return true;
@@ -113,14 +106,6 @@ public final class BundleItem extends Item implements Singleton {
 
         for (ItemStack removedItem : removedItems)
             player.drop(removedItem, true);
-    }
-
-    private void removeCarriedItem(Player player) {
-        player.inventoryMenu.setCarried(new ItemStack(Items.AIR));
-    }
-
-    private void removeItemFromSlot(Slot slot, ItemStack item) {
-        slot.remove(item.getCount());
     }
 
     private void addCarriedItem(ItemStack bundleStack, Player player) {

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
@@ -7,7 +7,6 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
-import java.util.Arrays;
 import java.util.Set;
 
 public class InventoryHelper {

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
@@ -1,9 +1,11 @@
-package com.castlelecs.missedbundle.utilities;
+package com.castlelecs.missedbundle.items.bundle.inventory;
 
+import com.castlelecs.missedbundle.utilities.Constants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -29,10 +31,24 @@ public class InventoryHelper {
         System.out.printf(Arrays.toString(getItems(bundle)) + "\n");
     }
 
+    public static ItemStack removeLast(ItemStack bundle) {
+        CompoundTag compoundTag = bundle.getOrCreateTag();
+        String[] keys = getKeys(compoundTag);
+
+        if (keys.length == 0)
+            return new ItemStack(Items.AIR);;
+
+        ListTag list = compoundTag.getList(keys[keys.length - 1], Tag.TAG_COMPOUND);
+        CompoundTag compound = list.getCompound(0);
+
+        compoundTag.remove(keys[keys.length - 1]);
+
+        return ItemStack.of(compound);
+    }
+
     public static ItemStack[] getItems(ItemStack bundle) {
         CompoundTag compoundTag = bundle.getOrCreateTag();
-        Set<String> setOfKeys = compoundTag.getAllKeys();
-        String[] keys = setOfKeys.toArray(new String[0]);
+        String[] keys = getKeys(compoundTag);
         ItemStack[] inventory = new ItemStack[keys.length];
 
         for (var index = 0; index < keys.length; index++) {
@@ -92,5 +108,11 @@ public class InventoryHelper {
     private static void putItemsToCompoundTag(CompoundTag tag, ItemStack newItems, ListTag list) {
         list.add(newItems.serializeNBT());
         tag.put(newItems.getDescriptionId(), list);
+    }
+
+    private static String[] getKeys(CompoundTag tag) {
+        Set<String> setOfKeys = tag.getAllKeys();
+
+        return setOfKeys.toArray(new String[0]);
     }
 }

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
@@ -39,11 +39,14 @@ public class InventoryHelper {
             return new ItemStack(Items.AIR);;
 
         ListTag list = compoundTag.getList(keys[keys.length - 1], Tag.TAG_COMPOUND);
-        CompoundTag compound = list.getCompound(0);
+        CompoundTag itemsCompound = list.getCompound(0);
 
         compoundTag.remove(keys[keys.length - 1]);
+        var removedItem = ItemStack.of(itemsCompound);
 
-        return ItemStack.of(compound);
+        return removedItem.getItem() == Items.AIR
+                ? removeLast(bundle)
+                : removedItem;
     }
 
     public static ItemStack[] removeAll(ItemStack bundle) {

--- a/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
+++ b/src/main/java/com/castlelecs/missedbundle/items/bundle/inventory/InventoryHelper.java
@@ -46,6 +46,17 @@ public class InventoryHelper {
         return ItemStack.of(compound);
     }
 
+    public static ItemStack[] removeAll(ItemStack bundle) {
+        int size = getItemsCount(bundle);
+        ItemStack[] removedItems = new ItemStack[size];
+
+        for (var index = 0; index < size; index++) {
+            removedItems[index] = removeLast(bundle);
+        }
+
+        return removedItems;
+    }
+
     public static ItemStack[] getItems(ItemStack bundle) {
         CompoundTag compoundTag = bundle.getOrCreateTag();
         String[] keys = getKeys(compoundTag);

--- a/src/main/java/com/castlelecs/missedbundle/utilities/Constants.java
+++ b/src/main/java/com/castlelecs/missedbundle/utilities/Constants.java
@@ -23,4 +23,8 @@ public class Constants {
     // MARK - Registry names
 
     public static String BUNDLE_REGISTRY_NAME = "bundle";
+
+    // MARK: - String names
+
+    public static String BUNDLE_FULLNESS_TEXT_INDICATOR = "item.missedbundle.bundle_fullness";
 }


### PR DESCRIPTION
# [Bug fix](https://trello.com/c/sf5WfkkR/28-нельзя-добавить-предмет-в-сумку-если-его-количества-больше-чем-поместится-в-сумке)

## Пример работы

https://user-images.githubusercontent.com/69932531/187063199-7c983f76-57b7-46c3-bd65-d6259602e2f5.mov

## Принцип работы

> Для фикса пришлось изменить систему определения возможности добавления предметов в сумку и дальнейшего обновления предметов в инвентаре.

Больше предметы не удаляются из руки или слота, для обновления предметов им присваивается количество:
```java
public static void saveItems(ItemStack newItem, ItemStack bundle) {
    int canAddCount = determineHowMuchCanBeAdded(bundle, newItem);

    if (canAddCount == 0)
        return;

    var list = new ListTag();
    CompoundTag compoundTag = bundle.getOrCreateTag();
    ItemStack itemsToAdd = newItem.copy();

    itemsToAdd.setCount(canAddCount);
    saveItemsToCompoundTag(compoundTag, itemsToAdd, list);
    bundle.setTag(compoundTag);
    newItem.setCount(newItem.getCount() - canAddCount);
}
```

Вместо определения возможности добавления предмета в сумку теперь определяется количество, которое можно добавить:
```java
private static int determineHowMuchCanBeAdded(ItemStack bundle, ItemStack newItem) {
    if (newItem.getMaxStackSize() == Constants.NON_STACKED_MAX_STACK_SIZE)
        return 0;

    ItemStack[] items = getItems(bundle);
    int itemsCount = getItemsCount(items);
    int jointCount = itemsCount + newItem.getCount();

    if (itemsCount == Constants.BUNDLE_SIZE) {
        return 0;
    } else if (jointCount < Constants.BUNDLE_SIZE) {
        return newItem.getCount();
    } else {
        return Constants.BUNDLE_SIZE - itemsCount;
    }
}
```